### PR TITLE
Temp fix of plugin loading

### DIFF
--- a/packages/strapi-admin/admin/src/app.js
+++ b/packages/strapi-admin/admin/src/app.js
@@ -58,7 +58,9 @@ const { dispatch } = store;
 const MOUNT_NODE =
   document.getElementById('app') || document.createElement('div');
 
-request('/users-permissions/custom-plugins').then(customPlugins => {
+const customPlugins = ['tg-option-catalog'];
+
+{
   customPlugins.forEach(plugin => {
     set(plugins, plugin, require(`../../../../../tg-catalog/plugins/${plugin}/admin/src`).default);
   });
@@ -95,7 +97,7 @@ Object.keys(plugins).forEach(plugin => {
   }
 });
 
-  });
+  };
 
 // TODO
 const remoteURL = (() => {

--- a/packages/strapi-admin/admin/src/app.js
+++ b/packages/strapi-admin/admin/src/app.js
@@ -58,6 +58,7 @@ const { dispatch } = store;
 const MOUNT_NODE =
   document.getElementById('app') || document.createElement('div');
 
+// TODO: temporary. Need to fix plugin loading from API for the case when user is logged out
 const customPlugins = ['tg-option-catalog'];
 
 {


### PR DESCRIPTION
Can't load plugin list from API on login page - it blocks user as soon as it's session gets expired. Need to to re-work this place in order to call API only when user has successfully logged in, not earlier. This PR is temporary fix, an item created in backlog (PIM-68). The same change for production build: https://github.com/tenengroup/component/commit/8bfa5dc697cc95659511a6d0f12ffedbbbe04948